### PR TITLE
Wrap UG_FONT struct byte array access with macro in case an accessor

### DIFF
--- a/ugui.c
+++ b/ugui.c
@@ -5298,7 +5298,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
 			 c=actual_char_width;
 			 for( i=0;i<bn;i++ )
 			 {
-				b = font->p[index++];
+				b = FONT_DATA_ACCESS(font->p[index++]);
 				for( k=0;(k<8) && c;k++ )
 				{
 				   if( b & 0x01 )
@@ -5322,7 +5322,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
 		   {
 			  for( i=0;i<actual_char_width;i++ )
 			  {
-				 b = font->p[index++];
+				 b = FONT_DATA_ACCESS(font->p[index++]);
 				 color = (((fc & 0xFF) * b + (bc & 0xFF) * (256 - b)) >> 8) & 0xFF |//Blue component
 				         (((fc & 0xFF00) * b + (bc & 0xFF00) * (256 - b)) >> 8)  & 0xFF00|//Green component
 				         (((fc & 0xFF0000) * b + (bc & 0xFF0000) * (256 - b)) >> 8) & 0xFF0000; //Red component
@@ -5344,7 +5344,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
            c=actual_char_width;
            for( i=0;i<bn;i++ )
            {
-             b = font->p[index++];
+             b = FONT_DATA_ACCESS(font->p[index++]);
              for( k=0;(k<8) && c;k++ )
              {
                if( b & 0x01 )
@@ -5371,7 +5371,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
             xo = x;
             for( i=0;i<actual_char_width;i++ )
             {
-               b = font->p[index++];
+               b = FONT_DATA_ACCESS(font->p[index++]);
                color = (((fc & 0xFF) * b + (bc & 0xFF) * (256 - b)) >> 8) & 0xFF |//Blue component
                        (((fc & 0xFF00) * b + (bc & 0xFF00) * (256 - b)) >> 8)  & 0xFF00|//Green component
                        (((fc & 0xFF0000) * b + (bc & 0xFF0000) * (256 - b)) >> 8) & 0xFF0000; //Red component

--- a/ugui_config.h
+++ b/ugui_config.h
@@ -34,6 +34,9 @@
 /* Specify platform-dependent integer types here */
 
 #define __UG_FONT_DATA const
+/* Override if you store font data not in RAM/SRAM
+ * for example for pgm_read_byte w/ PROGMEM on AVR */
+#define FONT_DATA_ACCESS(x) (x)
 typedef uint8_t      UG_U8;
 typedef int8_t       UG_S8;
 typedef uint16_t     UG_U16;


### PR DESCRIPTION
function is needed, as is the case on AVR if you use the PROGMEM
attribute in the __UG_FONT_DATA declaration
